### PR TITLE
use "roave/security-advisories:dev-latest" instead of "dev-master"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "roave/security-advisories": "dev-master",
+        "roave/security-advisories": "dev-latest",
         "laminas/laminas-coding-standard": "^2.3.0",
         "mezzio/mezzio-laminasrouter": "^3.0",
         "phpstan/phpstan": "^0.12.99",


### PR DESCRIPTION
As suggested in [Installation](https://github.com/Roave/SecurityAdvisories#installation) you should require "dev-latest"