### PR TITLE
Allow nested input filter definitions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        php-version: [ '8.0', '8.1', '8.2' ]
+        php-version: [ '8.1', '8.2' ]
         dependency: [ 'lowest', 'highest' ]
     name: PHP ${{ matrix.php-version }} [${{ matrix.dependency }}] on ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# 3.1
+
+### Changed
+
+* Make it possible to have nested input filter definitions
+
+### Removed
+
+* PHP 8.0 support removed
+
+
 # 3.0
 
 ### Added

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
     apt-get update
 
     # Install PHP and git
-    apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring php7.4-zip php7.4-curl php7.4-dom php7.4-xdebug php8.1-cli php8.1-xml php8.1-mbstring php8.1-zip php8.1-curl php8.1-dom php8.1-xdebug
+    apt-get install -y php8.1-cli php8.1-xml php8.1-mbstring php8.1-zip php8.1-curl php8.1-dom php8.1-xdebug
     apt-get install -y curl git unzip yamllint
 
     curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
         "psr-7"
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "laminas/laminas-filter": "^2.8",
         "laminas/laminas-http": "^2.7",
-        "laminas/laminas-inputfilter": "^2.19",
+        "laminas/laminas-inputfilter": "^2.27",
         "laminas/laminas-servicemanager": "^3.3",
         "laminas/laminas-stdlib": "^3.1",
         "laminas/laminas-validator": "^2.10",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: src/Extractor/OptionsExtractorFactory.php
 
 		-
-			message: "#^Call to an undefined method Laminas\\\\InputFilter\\\\InputFilterInterface\\|Laminas\\\\InputFilter\\\\InputInterface\\:\\:getName\\(\\)\\.$#"
-			count: 1
-			path: src/Validator/ValidationResult.php
-
-		-
-			message: "#^Parameter \\#3 \\$messages of class ZE\\\\ContentValidation\\\\Validator\\\\ValidationResult constructor expects array\\<string, array\\<string\\>\\>, array\\<string, array\\<array\\<string\\>\\|string\\>\\> given\\.$#"
+			message: "#^Parameter \\#2 \\$values of class ZE\\\\ContentValidation\\\\Validator\\\\ValidationResult constructor expects array, mixed given\\.$#"
 			count: 1
 			path: src/Validator/ValidationResult.php

--- a/src/Validator/ValidationResult.php
+++ b/src/Validator/ValidationResult.php
@@ -13,6 +13,9 @@ namespace ZE\ContentValidation\Validator;
 
 use Laminas\InputFilter\InputFilterInterface;
 
+/**
+ * @phpstan-import-type MessagesArray from ValidationResultInterface
+ */
 final class ValidationResult implements ValidationResultInterface
 {
     /**
@@ -26,7 +29,7 @@ final class ValidationResult implements ValidationResultInterface
     private array $values;
 
     /**
-     * @var array<string, string[]>
+     * @var MessagesArray
      */
     private array $messages;
 
@@ -40,7 +43,7 @@ final class ValidationResult implements ValidationResultInterface
      *
      * @param mixed[] $rawValues
      * @param mixed[] $values
-     * @param array<string, string[]> $messages
+     * @param MessagesArray $messages
      */
     public function __construct(
         array $rawValues,
@@ -59,8 +62,8 @@ final class ValidationResult implements ValidationResultInterface
         $messages = [];
 
         if (! $inputFilter->isValid()) {
-            foreach ($inputFilter->getInvalidInput() as $message) {
-                $messages[$message->getName()] = $message->getMessages();
+            foreach ($inputFilter->getInvalidInput() as $name => $message) {
+                $messages[$name] = $message->getMessages();
             }
         }
 
@@ -78,16 +81,25 @@ final class ValidationResult implements ValidationResultInterface
         return (count($this->messages) === 0);
     }
 
+    /**
+     * @return MessagesArray
+     */
     public function getMessages(): array
     {
         return $this->messages;
     }
 
+    /**
+     * @return mixed[]
+     */
     public function getRawValues(): array
     {
         return $this->rawValues;
     }
 
+    /**
+     * @return mixed[]
+     */
     public function getValues(): array
     {
         return $this->values;

--- a/src/Validator/ValidationResultInterface.php
+++ b/src/Validator/ValidationResultInterface.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace ZE\ContentValidation\Validator;
 
+/**
+ * @phpstan-type MessagesArray array<array<array<string[]|string>|string>>
+ */
 interface ValidationResultInterface
 {
     /**
@@ -23,7 +26,7 @@ interface ValidationResultInterface
     /**
      * Get validation messages
      *
-     * @return array<string, string[]>
+     * @return MessagesArray
      */
     public function getMessages(): array;
 

--- a/test/Extractor/ValidationResultTest.php
+++ b/test/Extractor/ValidationResultTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * ze-content-validation (https://github.com/func0der/ze-content-validation)
+ *
+ * @copyright Copyright (c) 2017 MVLabs(http://mvlabs.it)
+ * @copyright Copyright (c) 2021 func0der
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
+namespace ZETest\ContentValidation\Extractor;
+
+use Laminas\InputFilter\Input;
+use Laminas\InputFilter\InputFilter;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use ZE\ContentValidation\Validator\ValidationResult;
+
+class ValidationResultTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function itShouldProcessInvalidInputFiltersWithOnlyInputs(): void
+    {
+        $inputFilter = (new InputFilter())
+            ->add((new Input())->setRequired(true), 'foo')
+            ->add((new Input())->setRequired(true), 'bar');
+
+        $inputFilter->setData([]);
+
+        $validationResult = ValidationResult::buildFromInputFilter($inputFilter, 'dummy');
+
+        self::assertEquals(
+            [
+                'foo' => [
+                    'isEmpty' => 'Value is required and can\'t be empty',
+                ],
+                'bar' => [
+                    'isEmpty' => 'Value is required and can\'t be empty',
+                ],
+            ],
+            $validationResult->getMessages()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldProcessInvalidInputFiltersWithInputsAndInputFilters(): void
+    {
+        $inputFilter = (new InputFilter())
+            ->add((new Input())->setRequired(true), 'foo')
+            ->add(
+                (new InputFilter())
+                    ->add((new Input())->setRequired(true), 'nestedFooInBar'),
+                'bar'
+            );
+
+        $inputFilter->setData([]);
+
+        $validationResult = ValidationResult::buildFromInputFilter($inputFilter, 'dummy');
+
+        self::assertEquals(
+            [
+                'foo' => [
+                    'isEmpty' => 'Value is required and can\'t be empty',
+                ],
+                'bar' => [
+                    'nestedFooInBar' => [
+                        'isEmpty' => 'Value is required and can\'t be empty',
+                    ],
+                ],
+            ],
+            $validationResult->getMessages()
+        );
+    }
+}


### PR DESCRIPTION
To do nested input filter definitions, you basically need to `InputFilter::add()` an `InputFilterInterface` with the other inputs in them.

This is mostly needed for complex json or post data structures that one would like to validate.

We are changing the output of the `errors` key in `ProblemDetailsResponse` in that way, that we are adding new depth to the array.
This COULD result in issues, as the `value` of a `field` is supposed to be `array<string, string>` and now becomes `array<string, array<string, string[]|string>>` if that is even correct.
Theoretically there is not end to the depth of nesting input filters. We are just assuming one layer here.

I need opinions here, please. Is this a breaking change?

Laying all of those options out, my answer would be **yes**.

Not wanting to release another major so fast after the last one, I am also open to ideas on how to release this in `3.1` without breaking everything :D 